### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Aptos is a layer 1 blockchain bringing a paradigm shift to Web3 through better t
 * [Aptos Developer Network](https://aptos.dev)
 * [Guide - Integrate with the Aptos Blockchain](https://aptos.dev/guides/system-integrators-guide)
 * [Tutorials](https://aptos.dev/tutorials)
-* Follow us on [Twitter](https://twitter.com/Aptos).
+* Follow us on [Twitter](https://x.com/Aptos).
 * Join us on the [Aptos Discord](https://discord.gg/aptosnetwork).
 
 ## Contributing


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.

